### PR TITLE
fix documentation typo on max_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ checker.min_length = 8;
 
 // Change maximum length required
 // Default is: 0, which is effectively disabling of the check
-checker.min_length = 20;
+checker.max_length = 120;
 ```
 
 #### Require letters, numbers and symbols


### PR DESCRIPTION
This also uses a much higher suggested max_length because if someone is copying straight out of the README and doesn't realize this value is optional we don't want them limiting the security of a user's password unnecessarily.

Thanks for this great project, @nosco!